### PR TITLE
Remove unused direction map

### DIFF
--- a/golab.go
+++ b/golab.go
@@ -15,12 +15,6 @@ const (
 	cols = 40
 )
 
-var directionMap = map[Position]bot.Direction{
-	{0, 1}:  bot.Up,
-	{1, 0}:  bot.Right,
-	{0, -1}: bot.Down,
-	{-1, 0}: bot.Left,
-}
 
 const logicStep = 100 * time.Millisecond
 


### PR DESCRIPTION
## Summary
- drop unused `directionMap` from `golab.go`

## Testing
- `go vet ./...` *(fails: failed to download modules)*
- `go test ./...` *(fails: failed to download modules)*
- `go vet ./bot`
- `go test ./bot`


------
https://chatgpt.com/codex/tasks/task_e_6856bf945c20833380d33661a7dee918